### PR TITLE
Improve conda size and speed 

### DIFF
--- a/Dockerfile.conda
+++ b/Dockerfile.conda
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda:4.7.12
+FROM condaforge/mambaforge:latest
 
 ENV PIP_NO_CACHE_DIR=True
 ENV TINI_VERSION="v0.19.0"
@@ -7,7 +7,8 @@ ENV PATH="/project/.venv/bin:$PATH"
 COPY environment.yml ./
 
 RUN mkdir -p /project/.venv && \
-    conda env create -qp /project/.venv
+    mamba env create -qp /project/.venv && \
+    conda clean -afy
 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini

--- a/Dockerfile.conda-multistage
+++ b/Dockerfile.conda-multistage
@@ -1,16 +1,15 @@
-FROM continuumio/miniconda:4.7.12 as base
+FROM condaforge/miniforge3:latest as conda
 
-ENV PIP_NO_CACHE_DIR=True
+ADD conda-linux-64.lock /locks/conda-linux-64.lock
+RUN conda create -p /opt/env --copy --file /locks/conda-linux-64.lock
 
-COPY environment.yml ./
-
-RUN mkdir -p /project/.venv && \
-    conda env create -qp /project/.venv
-
+# Would be nice to use distroless but that needs the conda-forge tini package fixed
+# FROM gcr.io/distroless/base-debian10
 FROM ubuntu:20.04
-
 ENV TINI_VERSION="v0.19.0"
-ENV PATH="/project/.venv/bin:$PATH"
+ENV PATH="/opt/env/bin:$PATH"
+
+COPY --from=conda /opt/env /opt/env
 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
@@ -19,8 +18,6 @@ WORKDIR /project
 
 RUN useradd -m -r user && \
     chown user /project
-
-COPY --from=base /project/.venv /project/.venv
 
 COPY . .
 

--- a/conda-linux-64.lock
+++ b/conda-linux-64.lock
@@ -1,0 +1,27 @@
+# platform: linux-64
+# env_hash: fc79e40be15c1f23c58a5079cff251d0dbc0573fa7f393d46063168472562533
+@EXPLICIT
+https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
+https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2020.12.5-ha878542_0.tar.bz2#7eb5d4ffeee663caa1635cd67071bc1b
+https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.35.1-hea4e1c9_1.tar.bz2#cdabe198d509eeae33a9fc8741d7841d
+https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-9.3.0-h2ae2ef3_17.tar.bz2#342f3c931d0a3a209ab09a522469d20c
+https://conda.anaconda.org/conda-forge/linux-64/libgomp-9.3.0-h5dbcf3e_17.tar.bz2#8fd587013b9da8b52050268d50c12305
+https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-1_gnu.tar.bz2#561e277319a41d4f24f5c05a9ef63c04
+https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-9.3.0-h5dbcf3e_17.tar.bz2#fc9f5adabc4d55cd4b491332adc413e0
+https://conda.anaconda.org/conda-forge/linux-64/libffi-3.3-h58526e2_2.tar.bz2#665369991d8dd290ac5ee92fce3e6bf5
+https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.2-h58526e2_4.tar.bz2#509f2a21c4a09214cd737a480dfd80c9
+https://conda.anaconda.org/conda-forge/linux-64/openssl-1.1.1i-h7f98852_0.tar.bz2#bc63956d32024c8e0853ff2ca7f2bf05
+https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.5-h516909a_1.tar.bz2#33f601066901f3e1a85af3522a8113f9
+https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.11-h516909a_1010.tar.bz2#339cc5584e6d26bc73a875ba900028c3
+https://conda.anaconda.org/conda-forge/linux-64/readline-8.0-he28a2e2_2.tar.bz2#4d0ae8d473f863696088f76800ef9d38
+https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.10-h21135ba_1.tar.bz2#c647f70aa7e3d4cc4e029cc1c9a99953
+https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.34.0-h74cdb3f_0.tar.bz2#0a83e21e8c1929cc9a1e21ebb2459fc5
+https://conda.anaconda.org/conda-forge/linux-64/python-3.8.6-hffdb5ce_4_cpython.tar.bz2#e43784498e6c5983eb80ab00e7ba1c7c
+https://conda.anaconda.org/conda-forge/noarch/asgiref-3.3.1-pyhd8ed1ab_0.tar.bz2#8d202820f2b56547ed8bd87eba37ba57
+https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.8-1_cp38.tar.bz2#8d05152d6fb3012b27a0e6fbcc14bea1
+https://conda.anaconda.org/conda-forge/noarch/pytz-2020.5-pyhd8ed1ab_0.tar.bz2#9dbafab7fbbc1ef46a60858fb6320d8a
+https://conda.anaconda.org/conda-forge/noarch/sqlparse-0.4.1-pyh9f0ad1d_0.tar.bz2#009a8c5d2c3a17b25bfe79edeb64e0f3
+https://conda.anaconda.org/conda-forge/linux-64/certifi-2020.12.5-py38h578d9bd_1.tar.bz2#be470d89b0678991fd4ba67d4a35bc80
+https://conda.anaconda.org/conda-forge/noarch/django-3.1.5-pyhd8ed1ab_0.tar.bz2#dc2e06a8d5823309963a83ddf20c1653
+https://conda.anaconda.org/conda-forge/linux-64/setuptools-49.6.0-py38h578d9bd_3.tar.bz2#59c561cd1be0db9cf1c83f7d7cc74f4d
+https://conda.anaconda.org/conda-forge/linux-64/gunicorn-20.0.4-py38h578d9bd_3.tar.bz2#396e0f8a8d7b334493eec755c412e680

--- a/conda-osx-64.lock
+++ b/conda-osx-64.lock
@@ -1,0 +1,22 @@
+# platform: osx-64
+# env_hash: d61482897ba03ee2949a4cfee347e26fd4c55acf16e411d013d5ed64704c1219
+@EXPLICIT
+https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2020.12.5-h033912b_0.tar.bz2#4483d8ea13bd57b52e3539e741501a7d
+https://conda.anaconda.org/conda-forge/osx-64/libcxx-11.0.0-h4c3b8ed_1.tar.bz2#6a22f1c899bcf110c39cd6d959a8555e
+https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.2-h2e338ed_4.tar.bz2#9cef1910395d1543527583e73dba30f1
+https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.5-haf1e3a3_1.tar.bz2#41116deb499e9bc58048c297d6403ce6
+https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.11-h7795811_1010.tar.bz2#7d39e47e16ed0107f37c7224d5b5be8b
+https://conda.anaconda.org/conda-forge/osx-64/libffi-3.3-h046ec9c_2.tar.bz2#c7a196accaf92d40985d5c9b4d14f9cb
+https://conda.anaconda.org/conda-forge/osx-64/openssl-1.1.1i-h35c211d_0.tar.bz2#f26df9ccde4b41ff4d2b18c83c4d0fd3
+https://conda.anaconda.org/conda-forge/osx-64/readline-8.0-h0678c8f_2.tar.bz2#8f69d684fce8e73328995d7efb77816a
+https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.10-h0419947_1.tar.bz2#9a79a432473acddd936ff8bab8b86145
+https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.34.0-h17101e1_0.tar.bz2#9e9694f119bb1a2362a0cc0249651835
+https://conda.anaconda.org/conda-forge/osx-64/python-3.8.6-h624753d_4_cpython.tar.bz2#8832475a71a7a9b3eb94b550fe053705
+https://conda.anaconda.org/conda-forge/noarch/asgiref-3.3.1-pyhd8ed1ab_0.tar.bz2#8d202820f2b56547ed8bd87eba37ba57
+https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.8-1_cp38.tar.bz2#5fe7757fd743e1c2d14d6170d4f53365
+https://conda.anaconda.org/conda-forge/noarch/pytz-2020.5-pyhd8ed1ab_0.tar.bz2#9dbafab7fbbc1ef46a60858fb6320d8a
+https://conda.anaconda.org/conda-forge/noarch/sqlparse-0.4.1-pyh9f0ad1d_0.tar.bz2#009a8c5d2c3a17b25bfe79edeb64e0f3
+https://conda.anaconda.org/conda-forge/osx-64/certifi-2020.12.5-py38h50d1736_1.tar.bz2#fe528d606027dc2848f5a3577ab9b4eb
+https://conda.anaconda.org/conda-forge/noarch/django-3.1.5-pyhd8ed1ab_0.tar.bz2#dc2e06a8d5823309963a83ddf20c1653
+https://conda.anaconda.org/conda-forge/osx-64/setuptools-49.6.0-py38h50d1736_3.tar.bz2#af8a81ee7c2c09fc2884c800a044b616
+https://conda.anaconda.org/conda-forge/osx-64/gunicorn-20.0.4-py38h50d1736_3.tar.bz2#38b3449c33f795bc03235b4ffeef1abd

--- a/environment.yml
+++ b/environment.yml
@@ -1,25 +1,8 @@
 name: environment
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
-  - asgiref=3.3.1
-  - ca-certificates=2020.12.5
-  - certifi=2020.12.5
   - django=3.1.5
   - gunicorn=20.0.4
-  - libcxx=11.0.0
-  - libffi=3.3
-  - ncurses=6.2
-  - openssl=1.1.1i
-  - pip=20.3.3
-  - python=3.8.6
-  - python_abi=3.8
-  - pytz=2020.5
-  - readline=8.0
-  - setuptools=49.6.0
-  - sqlite=3.34.0
-  - sqlparse=0.4.1
-  - tk=8.6.10
-  - wheel=0.36.2
-  - xz=5.2.5
-  - zlib=1.2.11
+  - python=3.8


### PR DESCRIPTION
There could be some more improvements like using a `distroless` Docker image in the multistage approach or looking into the conda environment itself like I did for [pyarrow (1/2)](https://uwekorn.com/2020/09/08/trimming-down-pyarrow-conda-1-of-x.html) [pyarrow (2/2)](https://uwekorn.com/2020/10/28/trimming-down-pyarrow-conda-2-of-x.html) but I hope this already gives a much needed improvement.

What I did do as a rough worklog
---------------------------------

First, let's track the initial state. This is just to have a reference for later to compare to.

```
% docker history django-app-conda
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
001238a7147f   2 minutes ago   /bin/sh -c #(nop)  CMD ["gunicorn" "app.wsgi…   0B
c9d097f7cd6b   2 minutes ago   /bin/sh -c #(nop)  ENTRYPOINT ["/tini" "--"]    0B
0c73135bac5e   2 minutes ago   /bin/sh -c #(nop)  ENV GIT_HASH=dev             0B
8c6b08ba5048   2 minutes ago   /bin/sh -c #(nop)  ARG GIT_HASH                 0B
968d893e7915   2 minutes ago   /bin/sh -c #(nop)  USER user                    0B
e6d0f975cb42   2 minutes ago   /bin/sh -c #(nop) COPY dir:490db2620a7df8159…   54.8kB
82b27af516c8   2 minutes ago   /bin/sh -c useradd -m -r user &&     chown u…   333kB
106c869d1641   2 minutes ago   /bin/sh -c #(nop) WORKDIR /project              0B
71f33f1d5043   2 minutes ago   /bin/sh -c chmod +x /tini                       24.1kB
f071d7698462   2 minutes ago   /bin/sh -c #(nop) ADD 84b50f1acc38c999c31383…   24.1kB
87a11a1e80cb   2 minutes ago   /bin/sh -c mkdir -p /project/.venv &&     co…   619MB
150994ad8e78   5 minutes ago   /bin/sh -c #(nop) COPY file:b73654f065f6bec9…   436B
dedc5f11b6f6   5 minutes ago   /bin/sh -c #(nop)  ENV PATH=/project/.venv/b…   0B
818864eec719   5 minutes ago   /bin/sh -c #(nop)  ENV TINI_VERSION=v0.19.0     0B
564a42231e66   5 minutes ago   /bin/sh -c #(nop)  ENV PIP_NO_CACHE_DIR=True    0B
b8ea69b5c41c   15 months ago   /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>      15 months ago   /bin/sh -c wget --quiet https://repo.anacond…   131MB
<missing>      15 months ago   /bin/sh -c apt-get update --fix-missing &&  …   210MB
<missing>      15 months ago   /bin/sh -c #(nop)  ENV PATH=/opt/conda/bin:/…   0B
<missing>      15 months ago   /bin/sh -c #(nop)  ENV LANG=C.UTF-8 LC_ALL=C…   0B
<missing>      16 months ago   /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>      16 months ago   /bin/sh -c #(nop) ADD file:1901172d265456090…   69.2MB
```

```
uwe@Uwes-MBP-2 ~/Development/django-app-example (git)-[conda-size] % docker history django-app-conda-multistage
IMAGE          CREATED       CREATED BY                                      SIZE      COMMENT
f95adb113004   2 hours ago   /bin/sh -c #(nop)  CMD ["gunicorn" "app.wsgi…   0B
060f20f33a61   2 hours ago   /bin/sh -c #(nop)  ENTRYPOINT ["/tini" "--"]    0B
4e96b7e39f8a   2 hours ago   /bin/sh -c #(nop)  ENV GIT_HASH=dev             0B
5e851b1bba36   2 hours ago   /bin/sh -c #(nop)  ARG GIT_HASH                 0B
4e892a1f69aa   2 hours ago   /bin/sh -c #(nop)  USER user                    0B
eeb113ea04cd   2 hours ago   /bin/sh -c #(nop) COPY dir:490db2620a7df8159…   54.8kB
5a33e018bb09   2 hours ago   /bin/sh -c #(nop) COPY dir:736e05fce8d0cecd2…   213MB
b787a7e5aff8   2 hours ago   /bin/sh -c useradd -m -r user &&     chown u…   333kB
4397fd727b0f   2 hours ago   /bin/sh -c #(nop) WORKDIR /project              0B
c53bb949b8a9   2 hours ago   /bin/sh -c chmod +x /tini                       24.1kB
3d91af61b73b   2 hours ago   /bin/sh -c #(nop) ADD 84b50f1acc38c999c31383…   24.1kB
1ab91f4d53a3   2 hours ago   /bin/sh -c #(nop)  ENV PATH=/project/.venv/b…   0B
bbcd9497f060   2 hours ago   /bin/sh -c #(nop)  ENV TINI_VERSION=v0.19.0     0B
f643c72bc252   6 weeks ago   /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>      6 weeks ago   /bin/sh -c mkdir -p /run/systemd && echo 'do…   7B
<missing>      6 weeks ago   /bin/sh -c [ -z "$(apt-get indextargets)" ]     0B
<missing>      6 weeks ago   /bin/sh -c set -xe   && echo '#!/bin/sh' > /…   811B
<missing>      6 weeks ago   /bin/sh -c #(nop) ADD file:4f15c4475fbafb3fe…   72.9MB
```

```
% docker image ls 'django*'
REPOSITORY                    TAG       IMAGE ID       CREATED       SIZE
django-app-conda-multistage   latest    f95adb113004   2 hours ago   286MB
django-app-conda              latest    001238a7147f   2 hours ago   1.03GB
```


As the primary step, we look at the `environment.yml`:

```
name: environment
channels:
  - conda-forge
dependencies:
  - asgiref=3.3.1
  - ca-certificates=2020.12.5
  - certifi=2020.12.5
  - django=3.1.5
  - gunicorn=20.0.4
  - libcxx=11.0.0
  - libffi=3.3
  - ncurses=6.2
  - openssl=1.1.1i
  - pip=20.3.3
  - python=3.8.6
  - python_abi=3.8
  - pytz=2020.5
  - readline=8.0
  - setuptools=49.6.0
  - sqlite=3.34.0
  - sqlparse=0.4.1
  - tk=8.6.10
  - wheel=0.36.2
  - xz=5.2.5
  - zlib=1.2.11
```

This is a strict pinning of the libraries but we can see that the pinning was done on `osx-64` while we are actually building a Linux docker container.
The most obvious indicator is that the requirements contain `libcxx=11.0.0`. This is `clang`'s C++ library.
The two most popular conda distributions (anaconda and conda-forge) solely use `clang` as the main toolchain on macOS.

Having a strict pinning is really good for production but as the native libraries differ between operating systems, we we should have a pinning per OS.
From the poetry list, we can see what the intended pinning should be 

```
[tool.poetry.dependencies]
python = "^3.7"
django = "^3.1.5"
gunicorn = "^20.0.4"
```

Thus in the first commit in this PR, we then strip this pinning down to the poetry one.
I'll keep using Python 3.8 in this example, simply because here the conda-forge package is smaller and size matters ;)
Also we add the magic channel `nodefaults` as we only want to pull from conda-forge. In this case, this is mainly a tuning to make the build faster.
We then use that as the basis for the "single-stage" docker build which is probably nice if you want to do development.

```
% docker image ls 'django-app-conda'
REPOSITORY         TAG       IMAGE ID       CREATED          SIZE
django-app-conda   latest    3d6062b51086   19 seconds ago   964MB
```

This makes the image slightly smaller. 
If you have an existing environment and want to produce such a file but don't know what you actually typed into `conda install` you can use `conda env export --from-history` to get a loosely pinned conda export. This read-manpage-out-loud was actually my most popular Twitter post ever: https://twitter.com/xhochy/status/1199405251280936960

Next we look again at the individual layers:

```
% docker history django-app-conda                                                                                                 :(
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
3d6062b51086   3 minutes ago   /bin/sh -c #(nop)  CMD ["gunicorn" "app.wsgi…   0B
e06fc57d9b6c   3 minutes ago   /bin/sh -c #(nop)  ENTRYPOINT ["/tini" "--"]    0B
2c17750aa414   3 minutes ago   /bin/sh -c #(nop)  ENV GIT_HASH=dev             0B
b1455fbad06e   3 minutes ago   /bin/sh -c #(nop)  ARG GIT_HASH                 0B
565c78a9c16a   3 minutes ago   /bin/sh -c #(nop)  USER user                    0B
e2386709b4ed   3 minutes ago   /bin/sh -c #(nop) COPY dir:fc2c0ea046edbb4c0…   59.9kB
c3836825f846   3 minutes ago   /bin/sh -c useradd -m -r user &&     chown u…   333kB
673a9425a1b4   3 minutes ago   /bin/sh -c #(nop) WORKDIR /project              0B
1bb8bfa33720   3 minutes ago   /bin/sh -c chmod +x /tini                       24.1kB
c6cf9ca59965   3 minutes ago   /bin/sh -c #(nop) ADD 84b50f1acc38c999c31383…   24.1kB
79b07be250ef   3 minutes ago   /bin/sh -c mkdir -p /project/.venv &&     co…   554MB
7e15032d31d1   5 minutes ago   /bin/sh -c #(nop) COPY file:0e0a38dee3296824…   125B
dedc5f11b6f6   2 hours ago     /bin/sh -c #(nop)  ENV PATH=/project/.venv/b…   0B
818864eec719   2 hours ago     /bin/sh -c #(nop)  ENV TINI_VERSION=v0.19.0     0B
564a42231e66   2 hours ago     /bin/sh -c #(nop)  ENV PIP_NO_CACHE_DIR=True    0B
b8ea69b5c41c   15 months ago   /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>      15 months ago   /bin/sh -c wget --quiet https://repo.anacond…   131MB
<missing>      15 months ago   /bin/sh -c apt-get update --fix-missing &&  …   210MB
<missing>      15 months ago   /bin/sh -c #(nop)  ENV PATH=/opt/conda/bin:/…   0B
<missing>      15 months ago   /bin/sh -c #(nop)  ENV LANG=C.UTF-8 LC_ALL=C…   0B
<missing>      16 months ago   /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>      16 months ago   /bin/sh -c #(nop) ADD file:1901172d265456090…   69.2MB
```

Here we can see that the biggest layer is the one where we create the conda environment.
One of the issues is that we didn't clean up the caches after the installation.
We add a `conda clean -afy` at the end of the installation to remove them and don't persist them anywhere.
This saves us a whopping 300 MiB:

```
% docker image ls 'django-app-conda'
REPOSITORY         TAG       IMAGE ID       CREATED          SIZE
django-app-conda   latest    46b1959101f7   18 seconds ago   614MB
```

```
% docker history django-app-conda
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
46b1959101f7   13 seconds ago   /bin/sh -c #(nop)  CMD ["gunicorn" "app.wsgi…   0B
e7d2404c1e2a   13 seconds ago   /bin/sh -c #(nop)  ENTRYPOINT ["/tini" "--"]    0B
6246bf21981a   13 seconds ago   /bin/sh -c #(nop)  ENV GIT_HASH=dev             0B
f61f4ad5de3c   13 seconds ago   /bin/sh -c #(nop)  ARG GIT_HASH                 0B
ef31c207f956   14 seconds ago   /bin/sh -c #(nop)  USER user                    0B
4efbeb666c7b   14 seconds ago   /bin/sh -c #(nop) COPY dir:e86d76bfaa645fd13…   63.1kB
299720ecf448   14 seconds ago   /bin/sh -c useradd -m -r user &&     chown u…   333kB
ba617a681853   15 seconds ago   /bin/sh -c #(nop) WORKDIR /project              0B
a9a45c7a0ce0   15 seconds ago   /bin/sh -c chmod +x /tini                       24.1kB
6ea651302849   15 seconds ago   /bin/sh -c #(nop) ADD 84b50f1acc38c999c31383…   24.1kB
e4c7adf76015   18 seconds ago   /bin/sh -c mkdir -p /project/.venv &&     co…   204MB
7e15032d31d1   7 minutes ago    /bin/sh -c #(nop) COPY file:0e0a38dee3296824…   125B
dedc5f11b6f6   2 hours ago      /bin/sh -c #(nop)  ENV PATH=/project/.venv/b…   0B
818864eec719   2 hours ago      /bin/sh -c #(nop)  ENV TINI_VERSION=v0.19.0     0B
564a42231e66   2 hours ago      /bin/sh -c #(nop)  ENV PIP_NO_CACHE_DIR=True    0B
b8ea69b5c41c   15 months ago    /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B
<missing>      15 months ago    /bin/sh -c wget --quiet https://repo.anacond…   131MB
<missing>      15 months ago    /bin/sh -c apt-get update --fix-missing &&  …   210MB
<missing>      15 months ago    /bin/sh -c #(nop)  ENV PATH=/opt/conda/bin:/…   0B
<missing>      15 months ago    /bin/sh -c #(nop)  ENV LANG=C.UTF-8 LC_ALL=C…   0B
<missing>      16 months ago    /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>      16 months ago    /bin/sh -c #(nop) ADD file:1901172d265456090…   69.2MB
```

But as installation is taking a bit too long for my nerves as I would consider this to be the development setup where you quickly interate over things, we switch to `mamba` as a drop-in replacement for `conda` which provides nearly the same functionality just enormously faster.
Luckily conda-forge already has a Docker image with mamba pre-installed: `conda-forge/mambaforge`.
It also saves an additional 20MiB but at this stage, this doesn't matter that much.

```
% docker image ls 'django-app-conda'
REPOSITORY         TAG       IMAGE ID       CREATED          SIZE
django-app-conda   latest    1cacc208be3a   18 seconds ago   596MB
```

This is now the optimized development setup. For a production case, I can definitely recommend to pin the dependencies. For this use case there is the https://github.com/conda-incubator/conda-lock tool. It takes an `environment.yml` and can generate explicit pinning files for several architectures.
These pinning files provide excellent reproducibility as when you install with them, you get the exact same environment every time.
Also as they are marked as explicit pinning, they skip the solver in conda and are thus install much faster to install.

We pin with `conda-lock -f environment.yml -p osx-64 -p linux-64` and change the Dockerfile as in the linked commit.

```
docker image ls django-app-conda-multistage
REPOSITORY                    TAG       IMAGE ID       CREATED       SIZE
django-app-conda-multistage   latest    f95adb113004   2 hours ago   286MB
```

down to

```
% docker image ls django-app-conda-multistage
REPOSITORY                    TAG       IMAGE ID       CREATED          SIZE
django-app-conda-multistage   latest    d47dddf71be2   13 seconds ago   268MB
```

Minimal improvement in size but hopefully a huge improvement in stability.


